### PR TITLE
Fix a bug in epubParser.ts where Epub.resolve() fails to resolve files with Percent-encoded paths

### DIFF
--- a/src/epubParser.ts
+++ b/src/epubParser.ts
@@ -82,7 +82,7 @@ export class Epub {
     } else {
       _path = this._root + path
     }
-    const file = this._zip.file(_path)
+    const file = this._zip.file(decodeURI(_path))
     if (file) {
       return file
     } else {


### PR DESCRIPTION
Example error:
`Error: OEBPS/Text/Tome%202%20-%20Harry%20Potter%20et%20la%20chambre%20des%20secrets.htm not found!`

Problematic epub: [hp2-french-epub.zip](https://github.com/gaoxiaoliangz/epub-parser/files/1268213/hp2-french-epub.zip)

