### PR TITLE
parse html table of contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "jest",
     "test-debug": "node --inspect-brk -r ts-node/register node_modules/.bin/jest --runInBand",
     "v": "standard-version --preset angular",
-    "postv": "git push --follow-tags origin master"
+    "postv": "git push --follow-tags origin master",
+    "prepare": "yarn build"
   },
   "repository": {
     "type": "git",

--- a/src/parseEpub.ts
+++ b/src/parseEpub.ts
@@ -241,7 +241,7 @@ export class Epub {
     // https://github.com/gaoxiaoliangz/epub-parser/issues/13
     // https://www.w3.org/publishing/epub32/epub-packages.html#sec-spine-elem
 
-    const tocPath = _.find(manifest, { id: tocID })?.href
+    const tocPath = (_.find(manifest, { id: tocID }) || {}).href
     if (tocPath) {
       const toc = await this._resolveXMLAsJsObject(tocPath)
       this._toc = toc

--- a/src/parseEpub.ts
+++ b/src/parseEpub.ts
@@ -130,7 +130,54 @@ export class Epub {
     )
   }
 
+  _genStructureForHTML(tocObj: GeneralObject) {
+    const tocRoot = tocObj.html.body[0].nav[0]['ol'][0].li;
+    let runningIndex = 1;
+
+    const parseHTMLNavPoints = (navPoint: GeneralObject) => {
+      const element = navPoint.a[0] || {};
+      const path = element['$'].href;
+      let name = element['_'];
+      const prefix = element.span;
+      if (prefix) {
+        name = `${prefix.map((p: GeneralObject) => p['_']).join('')}${name}`;
+      }
+      const sectionId = this._resolveIdFromLink(path);
+      const { hash: nodeId } = parseLink(path)
+      const playOrder = runningIndex;
+
+      let children = navPoint?.ol?.[0]?.li;
+
+      if (children) {
+        children = parseOuterHTML(children);
+      }
+
+      runningIndex++;
+
+      return {
+        name,
+        sectionId,
+        nodeId,
+        path,
+        playOrder,
+        children,
+      };
+    };
+
+    const parseOuterHTML = (collection: GeneralObject[]) => {
+      return collection.map((point) => {
+        return parseHTMLNavPoints(point);
+      });
+    }
+
+    return parseOuterHTML(tocRoot);
+  }
+
   _genStructure(tocObj: GeneralObject, resolveNodeId = false) {
+    if (tocObj.html) {
+      return this._genStructureForHTML(tocObj);
+    }
+
     const rootNavPoints = _.get(tocObj, ['ncx', 'navMap', '0', 'navPoint'], [])
 
     const parseNavPoint = (navPoint: GeneralObject) => {
@@ -190,13 +237,12 @@ export class Epub {
     const content = await this._resolveXMLAsJsObject('/' + opfPath)
     const manifest = this._getManifest(content)
     const metadata = _.get(content, ['package', 'metadata'], [])
-    const tocID = _.get(content, ['package', 'spine', 0, '$', 'toc'], '')
-
+    const tocID = _.get(content, ['package', 'spine', 0, '$', 'toc'], 'toc.xhtml');
     // https://github.com/gaoxiaoliangz/epub-parser/issues/13
     // https://www.w3.org/publishing/epub32/epub-packages.html#sec-spine-elem
-    // TOC is optional
-    if (tocID) {
-      const tocPath = _.find(manifest, { id: tocID }).href
+
+    const tocPath = _.find(manifest, { id: tocID })?.href
+    if (tocPath) {
       const toc = await this._resolveXMLAsJsObject(tocPath)
       this._toc = toc
       this.structure = this._genStructure(toc)


### PR DESCRIPTION
## What's in this PR?

In the latest Epub spec, NCX table of contents are being deprecated in favor of html.  This PR introduces a `getStructureForHTML` function that will build the table of contents if an `ncx` one isn't available but a `toc.xhtml` one is.