### PR TITLE
Fixed image loading on windows

### DIFF
--- a/src/parseSection.ts
+++ b/src/parseSection.ts
@@ -64,7 +64,7 @@ export class Section {
       resolveSrc: (src) => {
         if (isInternalUri(src)) {
           // todo: may have bugs
-          const absolutePath = path.resolve('/', src).substr(1)
+          const absolutePath = path.posix.resolve('/', src).substr(1)
           const buffer = this._resourceResolver?.(absolutePath)?.asNodeBuffer()
           const base64 = buffer.toString('base64')
           return `data:image/png;base64,${base64}`


### PR DESCRIPTION
The issue with #14 was that path library works differently on Windows and POSIX. So the `path.resolve('/', "../images/00002.jpeg")` returned `"/images/00002.jpeg"` on POSIX and `"C:\images\00002.jpeg"` on Windows.

Happily there is a way to achieve consistent results by using `path.posix` instead of just `path`.