### PR TITLE
add filename to sections

### DIFF
--- a/src/parseEpub.ts
+++ b/src/parseEpub.ts
@@ -222,6 +222,7 @@ export class Epub {
 
       return parseSection({
         id,
+        filename: path,
         htmlString: html,
         resourceResolver: this.resolve.bind(this),
         idResolver: this._resolveIdFromLink.bind(this),

--- a/src/parseSection.ts
+++ b/src/parseSection.ts
@@ -12,6 +12,7 @@ const isInternalUri = (uri: string) => {
 
 export type ParseSectionConfig = {
   id: string
+  filename: string
   htmlString: string
   resourceResolver: (path: string) => any
   idResolver: (link: string) => string
@@ -20,13 +21,15 @@ export type ParseSectionConfig = {
 
 export class Section {
   id: string
+  filename: string
   htmlString: string
   htmlObjects?: HtmlNodeObject[]
   private _resourceResolver?: (path: string) => any
   private _idResolver?: (link: string) => string
 
-  constructor({ id, htmlString, resourceResolver, idResolver, expand }: ParseSectionConfig) {
+  constructor({ id, filename, htmlString, resourceResolver, idResolver, expand }: ParseSectionConfig) {
     this.id = id
+    this.filename = filename
     this.htmlString = htmlString
     this._resourceResolver = resourceResolver
     this._idResolver = idResolver


### PR DESCRIPTION
Have sections include filename. This is useful when trying to figure out HTML `<a href="file.html">`, to what section is that link.